### PR TITLE
Add SwiftUI business dashboard with QR support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Firebase functions
+functions/node_modules/
+functions/package-lock.json

--- a/Common/Extensions/String+QRCode.swift
+++ b/Common/Extensions/String+QRCode.swift
@@ -1,0 +1,14 @@
+import UIKit
+import CoreImage.CIFilterBuiltins
+
+extension String {
+    func qrCodeImage(scale: CGFloat = 10) -> UIImage? {
+        let data = Data(self.utf8)
+        let filter = CIFilter.qrCodeGenerator()
+        filter.setValue(data, forKey: "inputMessage")
+        guard let output = filter.outputImage else { return nil }
+        let transform = CGAffineTransform(scaleX: scale, y: scale)
+        let img = UIImage(ciImage: output.transformed(by: transform))
+        return img
+    }
+}

--- a/Controllers/Dashboard/BusinessDashboardView.swift
+++ b/Controllers/Dashboard/BusinessDashboardView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct BusinessDashboardView: View {
+    @StateObject private var viewModel = BusinessDashboardViewModel()
+    @State private var showScanner = false
+    @State private var scannerResult: String?
+
+    var body: some View {
+        NavigationView {
+            List {
+                if !viewModel.rules.isEmpty {
+                    Section(header: Text("Rules")) {
+                        ForEach(viewModel.rules, id: \.documentId) { rule in
+                            Text("\(rule.triggerType): \(rule.threshold)")
+                        }
+                    }
+                }
+                if !viewModel.pendingDeals.isEmpty {
+                    Section(header: Text("Pending Deals")) {
+                        ForEach(viewModel.pendingDeals, id: \.documentId) { deal in
+                            Text(deal.about)
+                        }
+                    }
+                }
+                if !viewModel.approvals.isEmpty {
+                    Section(header: Text("Approvals")) {
+                        ForEach(viewModel.approvals, id: \.documentId) { deal in
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(deal.about)
+                                    if let qr = deal.documentId.qrCodeImage() {
+                                        Image(uiImage: qr)
+                                            .resizable()
+                                            .frame(width: 80, height: 80)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .listStyle(GroupedListStyle())
+            .navigationTitle("Dashboard")
+            .toolbar {
+                Button("Scan") {
+                    showScanner = true
+                }
+            }
+            .onAppear {
+                viewModel.load()
+            }
+            .sheet(isPresented: $showScanner) {
+                QRScannerView { code in
+                    scannerResult = code
+                    viewModel.redeem(dealId: code)
+                }
+            }
+        }
+    }
+}
+
+struct BusinessDashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        BusinessDashboardView()
+    }
+}

--- a/Controllers/Dashboard/BusinessDashboardViewModel.swift
+++ b/Controllers/Dashboard/BusinessDashboardViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Combine
+
+class BusinessDashboardViewModel: ObservableObject {
+    @Published var rules: [Rule] = []
+    @Published var pendingDeals: [DealItem] = []
+    @Published var approvals: [DealItem] = []
+
+    func load() {
+        FirestoreManager.shared.fetchRules { [weak self] in self?.rules = $0 ?? [] }
+        FirestoreManager.shared.fetchPendingDeals { [weak self] in self?.pendingDeals = $0 ?? [] }
+        FirestoreManager.shared.fetchApprovals { [weak self] in self?.approvals = $0 ?? [] }
+    }
+
+    func redeem(dealId: String) {
+        FirestoreManager.shared.redeemApprovedDeal(id: dealId) { _ in }
+    }
+}

--- a/Controllers/Dashboard/QRScannerView.swift
+++ b/Controllers/Dashboard/QRScannerView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct QRScannerView: UIViewControllerRepresentable {
+    var completion: (String) -> Void
+
+    func makeUIViewController(context: Context) -> QRScannerViewController {
+        let controller = QRScannerViewController()
+        controller.onCodeScanned = completion
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: QRScannerViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- create SwiftUI dashboard showing rules, pending deals and approvals
- generate QR codes for each approved deal
- add QR scanner integration
- extend FirestoreManager with approvals collection
- ignore Firebase function artifacts

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_688bb63aaa1c83279147ac7d517bd399