### PR TITLE
Add packaging script and AI function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Node modules from Firebase functions
+functions/node_modules/
+functions/package-lock.json
+
+# Release packages
+SmartDeal_release.zip

--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ firebase deploy --only functions
 ```
 
 Ensure that you have initialized Firebase for this project and are logged in using the Firebase CLI before running the deployment command.
+
+## Packaging a Release
+
+To bundle the cloud functions, iOS source and any available PDF documentation into a single archive run:
+
+```bash
+bash scripts/package_release.sh
+```
+
+The script produces `SmartDeal_release.zip` in the repository root containing the `functions/`, `Application/`, `Controllers/`, `Common/` and `Resources/` directories along with any `*.pdf` files it finds.

--- a/functions/index.js
+++ b/functions/index.js
@@ -48,13 +48,22 @@ exports.evaluateSmartDeals = functions.https.onCall(async (data, context) => {
   return { evaluated };
 });
 
-exports.generateAISmartDealSuggestion = functions.https.onCall(async (data, context) => {
-  const keywords = data.keywords || [];
-  const suggestions = keywords.map((word) => ({
+function buildAiSuggestions(keywords = []) {
+  return keywords.map((word) => ({
     id: uuidv4(),
     title: `Smart deal for ${word}`,
     description: `Automatically generated suggestion for ${word}`,
   }));
+}
+
+exports.generateAISmartDealSuggestion = functions.https.onCall(async (data, context) => {
+  const suggestions = buildAiSuggestions(data.keywords || []);
+  return { suggestions };
+});
+
+// Expose AI recommendation hook for future integration
+exports.aiRecommendation = functions.https.onCall(async (data, context) => {
+  const suggestions = buildAiSuggestions(data.keywords || []);
   return { suggestions };
 });
 

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+OUTPUT=${1:-SmartDeal_release.zip}
+TMP_DIR=$(mktemp -d)
+OUTPUT_PATH="$PWD/$OUTPUT"
+
+# copy server functions
+cp -r functions "$TMP_DIR/"
+# copy iOS source directories
+cp -r Application Controllers Common Resources "$TMP_DIR/"
+
+# gather documentation PDFs if any
+mkdir -p "$TMP_DIR/Documentation"
+shopt -s nullglob
+for pdf in Documentation/*.pdf *.pdf; do
+  cp "$pdf" "$TMP_DIR/Documentation/" 2>/dev/null || true
+done
+shopt -u nullglob
+
+( cd "$TMP_DIR" && zip -r "$OUTPUT_PATH" . )
+rm -rf "$TMP_DIR"
+
+echo "Release package created: $OUTPUT_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/package_release.sh` to bundle release assets
- document release packaging in README
- expose AI recommendation as a callable function
- ignore Firebase function dependencies and release zip

## Testing
- `bash scripts/package_release.sh`


------
https://chatgpt.com/codex/tasks/task_e_688bb63e44b48327a9442535a4b7938d