### PR TITLE
Support user preferences

### DIFF
--- a/Common/FirestoreManager.swift
+++ b/Common/FirestoreManager.swift
@@ -296,6 +296,12 @@ class FirestoreManager {
                                   ProfileKey.gender: profile.gender?.rawValue ?? NSNull(),
                                   ProfileKey.creationDate: Timestamp(date: profile.creationDate),
                                   ProfileKey.avatar: profile.avatarUrl?.absoluteString ?? ""]
+
+        let preferences: [String: Any] = [
+            ProfileKey.interests: profile.preferences.interests,
+            ProfileKey.preferredBusinessTypes: profile.preferences.preferredBusinessTypes
+        ]
+        data[ProfileKey.preferences] = preferences
         
         if profile.isBusinessOwner {
             data[ProfileKey.category] = profile.category
@@ -334,11 +340,22 @@ class FirestoreManager {
         guard let collection = profile.type.name, !profile.uid.isEmpty else {
             return completion(true)
         }
-        
+
+        var dataToSave = data
+        var preferences = dataToSave[ProfileKey.preferences] as? [String: Any] ?? [:]
+        if let interests = dataToSave.removeValue(forKey: ProfileKey.interests) {
+            preferences[ProfileKey.interests] = interests
+        }
+        if let types = dataToSave.removeValue(forKey: ProfileKey.preferredBusinessTypes) {
+            preferences[ProfileKey.preferredBusinessTypes] = types
+        }
+        if !preferences.isEmpty {
+            dataToSave[ProfileKey.preferences] = preferences
+        }
 
         db.collection(collection)
             .document(profile.uid)
-            .setData(data, merge: true) { error in
+            .setData(dataToSave, merge: true) { error in
                 completion(error == nil)
             }
     }

--- a/Common/Model/Profile.swift
+++ b/Common/Model/Profile.swift
@@ -24,6 +24,9 @@ struct ProfileKey {
     static let isOnlineStore = "isOnlineStore"
     static let userId = "userId"
     static let lastLocation = "lastLocation"
+    static let preferences = "preferences"
+    static let interests = "interests"
+    static let preferredBusinessTypes = "preferredBusinessTypes"
 }
 
 enum ProfileType: Codable {
@@ -52,6 +55,11 @@ enum ProfileType: Codable {
     }
 }
 
+struct Preferences: Codable {
+    var interests: [String] = []
+    var preferredBusinessTypes: [String] = []
+}
+
 struct Profile: Codable {
     let uid: String
     let email: String
@@ -59,8 +67,9 @@ struct Profile: Codable {
     var surname: String = ""
     var type: ProfileType
     var avatarUrl: URL?
-    
-    
+    var preferences: Preferences = Preferences()
+
+
     //for Business Owner
     var category: String = ""
     var businessName: String = ""
@@ -101,7 +110,12 @@ struct Profile: Codable {
         self.gender = Gender(rawValue: data[ProfileKey.gender] as? String ?? "")
         self.avatarUrl = URL(string: data[ProfileKey.avatar] as? String ?? "")
         self.creationDate = creationDate.dateValue()
-        
+
+        if let prefData = data[ProfileKey.preferences] as? [String: Any] {
+            self.preferences.interests = prefData[ProfileKey.interests] as? [String] ?? []
+            self.preferences.preferredBusinessTypes = prefData[ProfileKey.preferredBusinessTypes] as? [String] ?? []
+        }
+
         //For Business Owener
         self.category = data[ProfileKey.category] as? String ?? ""
         self.category = data[ProfileKey.category] as? String ?? ""

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function validPreferences(pref) {
+      return pref == null ||
+             (pref.interests is list && pref.interests.size() >= 0 &&
+              pref.preferredBusinessTypes is list && pref.preferredBusinessTypes.size() >= 0);
+    }
+
+    match /Customers/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow create, update: if request.auth != null &&
+                            request.auth.uid == userId &&
+                            validPreferences(request.resource.data.preferences);
+    }
+
+    match /Business/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow create, update: if request.auth != null &&
+                            request.auth.uid == userId &&
+                            validPreferences(request.resource.data.preferences);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend `Profile` model with user preferences arrays
- handle new arrays in Firestore writes
- add base Firestore security rules validating preference arrays

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bbe0608008327b0c26cd4a333fa5c