### PR TITLE
Add user-specific deal retrieval

### DIFF
--- a/Common/FirestoreManager.swift
+++ b/Common/FirestoreManager.swift
@@ -682,6 +682,24 @@ class FirestoreManager {
             }
         }
     }
+
+    func fetchAvailableDeals(completion: @escaping ([DealItem]?)->Void) {
+        guard let userId = FirestoreManager.shared.currentUser?.uid else {
+            Coordinator.redirectToAuth()
+            return
+        }
+
+        db.collection("users")
+            .document(userId)
+            .collection("availableDeals")
+            .getDocuments { snapshot, error in
+                guard error == nil else { return completion(nil) }
+
+                var result = (snapshot?.documents ?? []).compactMap { DealItem($0) }
+                result = result.filter { $0.approved && !$0.isExpired }
+                completion(result)
+            }
+    }
     
     func updateDealRating(_ value: Int, dealId: String, completion: @escaping (String?)->Void) {
         guard let userId = FirestoreManager.shared.currentUser?.uid else {

--- a/Controllers/Search/View/SearchViewController.swift
+++ b/Controllers/Search/View/SearchViewController.swift
@@ -169,7 +169,7 @@ class SearchViewController: UIViewController {
         if tableData.isEmpty {
             activityIndicatorContainer.startActivityAnimating()
         }
-        FirestoreManager.shared.fetchDeals { [unowned self] deals in
+        FirestoreManager.shared.fetchAvailableDeals { [unowned self] deals in
             self.activityIndicatorContainer.stopActivityAnimating()
             self.allDeals = deals?.filter { $0.approved }
             self.filterDeals()
@@ -230,13 +230,9 @@ class SearchViewController: UIViewController {
     }
     
     func fetchDeals(category: DealCategory) {
-        FirestoreManager.shared.fetchDeals(categoryId: category.documentId) { [weak self] data in
-            guard let self = self else { return }
-
-            self.activityIndicatorContainer.stopActivityAnimating()
-            self.tableData = (data ?? []).filter { $0.approved }
-            self.noDealsView.isHidden = !self.tableData.isEmpty
-        }
+        activityIndicatorContainer.stopActivityAnimating()
+        tableData = (allDeals ?? []).filter { $0.categories.contains(category.documentId) }
+        noDealsView.isHidden = !tableData.isEmpty
     }
     
     func loadCategories() {


### PR DESCRIPTION
## Summary
- support pulling deals from `users/{userId}/availableDeals`
- display personalized deals in Explore and Search views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bbff235d483278d9f94e9720976e5