### PR TITLE
Add preferences editing screen

### DIFF
--- a/Controllers/Settings/PreferencesView.swift
+++ b/Controllers/Settings/PreferencesView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    @Environment(\.presentationMode) private var presentationMode
+    @State private var interestsText: String
+    @State private var typesText: String
+    @State private var isSaving = false
+
+    init(profile: Profile = UserManager.shared.profile ?? .zeroCustomer()) {
+        _interestsText = State(initialValue: profile.preferences.interests.joined(separator: "\n"))
+        _typesText = State(initialValue: profile.preferences.preferredBusinessTypes.joined(separator: "\n"))
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Interests")) {
+                    TextEditor(text: $interestsText)
+                        .frame(minHeight: 100)
+                }
+                Section(header: Text("Preferred Business Types")) {
+                    TextEditor(text: $typesText)
+                        .frame(minHeight: 100)
+                }
+            }
+            .navigationTitle("Preferences")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { presentationMode.wrappedValue.dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if isSaving {
+                        ProgressView()
+                    } else {
+                        Button("Save") { save() }
+                    }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        isSaving = true
+        let interests = interestsText
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let types = typesText
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        FirestoreManager.shared.updateProfile(
+            data: [ProfileKey.interests: interests,
+                   ProfileKey.preferredBusinessTypes: types]
+        ) { success in
+            if success {
+                if var profile = UserManager.shared.profile {
+                    profile.preferences.interests = interests
+                    profile.preferences.preferredBusinessTypes = types
+                    UserManager.shared.profile = profile
+                }
+            }
+            isSaving = false
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
+}
+
+struct PreferencesView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreferencesView()
+    }
+}

--- a/Controllers/Settings/PreferencesViewController.swift
+++ b/Controllers/Settings/PreferencesViewController.swift
@@ -1,0 +1,20 @@
+import UIKit
+import SwiftUI
+
+class PreferencesViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let preferencesView = PreferencesView()
+        let host = UIHostingController(rootView: preferencesView)
+        addChild(host)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(host.view)
+        NSLayoutConstraint.activate([
+            host.view.topAnchor.constraint(equalTo: view.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            host.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        host.didMove(toParent: self)
+    }
+}

--- a/Controllers/Settings/SettingsViewController.swift
+++ b/Controllers/Settings/SettingsViewController.swift
@@ -44,6 +44,11 @@ class SettingsViewController: UIViewController {
             open(url: url)
         }
     }
+
+    private func openPreferences() {
+        let vc = PreferencesViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
     
     private func logout() {
         guard !loadingView.isAnimating else { return }
@@ -104,6 +109,8 @@ extension SettingsViewController: UITableViewDataSource, UITableViewDelegate {
             sendEmail()
         case .website:
             websiteOpen()
+        case .preferences:
+            openPreferences()
         case .logout:
             logout()
         case .deleteAccount:
@@ -120,7 +127,7 @@ extension SettingsViewController: MFMailComposeViewControllerDelegate {
 }
 
 enum SettingsItem: CaseIterable {
-    case sendEmail, website, logout, deleteAccount
+    case sendEmail, website, preferences, logout, deleteAccount
     
     var title: String {
         switch self {
@@ -128,6 +135,8 @@ enum SettingsItem: CaseIterable {
             return "Send Email"
         case .website:
             return "Website"
+        case .preferences:
+            return "Preferences"
         case .logout:
             return "Logout"
         case .deleteAccount:


### PR DESCRIPTION
## Summary
- add PreferencesView SwiftUI screen for editing interests and preferred business types
- host PreferencesView in PreferencesViewController
- integrate PreferencesViewController into Settings screen

## Testing
- `bash scripts/package_release.sh test_release.zip`

------
https://chatgpt.com/codex/tasks/task_e_688bc17761dc8327a2f8ce2b16d8cda1