### PR TITLE
Add Firestore users.businessId index

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ firebase deploy --only functions
 
 Ensure that you have initialized Firebase for this project and are logged in using the Firebase CLI before running the deployment command.
 
+## Firestore Indexes
+
+The project defines Firestore composite indexes in `firestore.indexes.json`. To deploy the indexes along with rules and functions run:
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+This will create the index on `users.businessId` required for querying users by business.
+
 ## Packaging a Release
 
 To bundle the cloud functions, iOS source and any available PDF documentation into a single archive run:

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "businessId", "order": "ASCENDING"},
+        {"fieldPath": "__name__", "order": "ASCENDING"}
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- create `firestore.indexes.json` defining a composite index on `users.businessId`
- document how to deploy indexes in the README

## Testing
- `npm test --silent` *(fails: no test script defined)*
- `firebase --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc35229d083279513353d79edcdb5