### PR TITLE
Add rule for available deals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ firebase deploy --only firestore:indexes
 
 This will create the index on `users.businessId` required for querying users by business.
 
+## Firestore Rules
+
+Security rules for Firestore reside in `firestore.rules`. After updating the rules, deploy them with:
+
+```bash
+firebase deploy --only firestore:rules
+```
+
+Customers now have an `availableDeals` subcollection which restricts access so a user can only read or write their own deals:
+
+```
+match /Customers/{userId}/availableDeals/{docId} {
+  allow read, write: if request.auth != null && request.auth.uid == userId;
+}
+```
+
 ## Packaging a Release
 
 To bundle the cloud functions, iOS source and any available PDF documentation into a single archive run:

--- a/firestore.rules
+++ b/firestore.rules
@@ -13,6 +13,10 @@ service cloud.firestore {
       allow create, update: if request.auth != null &&
                             request.auth.uid == userId &&
                             validPreferences(request.resource.data.preferences);
+
+      match /availableDeals/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
     }
 
     match /Business/{userId} {


### PR DESCRIPTION
## Summary
- add a security rule for `availableDeals` under `Customers`
- document how to deploy rules in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `firebase deploy --only firestore:rules` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bccc5d82483278cfacb01f61c344a