### PR TITLE
Add businesses Firestore rules and Swift helpers

### DIFF
--- a/Common/FirestoreManager.swift
+++ b/Common/FirestoreManager.swift
@@ -28,6 +28,16 @@ let COLLECTION_DELETION_QUEUE = "DeletionQueue"
 let COLLECTION_RULES = "Rules"
 let COLLECTION_ANALYTICS = "Analytics"
 let COLLECTION_APPROVALS = "Approvals"
+let COLLECTION_BUSINESSES = "businesses"
+let COLLECTION_BUSINESS_SETTINGS = "settings"
+let COLLECTION_BUSINESS_EPOS_CONFIG = "eposConfig"
+let COLLECTION_BUSINESS_INVENTORY = "inventory"
+let COLLECTION_BUSINESS_SALES = "sales"
+let COLLECTION_BUSINESS_RULES = "rules"
+let COLLECTION_BUSINESS_ACTIVE_DEAL = "activeDeal"
+let COLLECTION_BUSINESS_ANALYTICS = "analytics"
+let COLLECTION_BUSINESS_RULE_ADJUSTMENTS = "ruleAdjustments"
+let COLLECTION_BUSINESS_NOTIFICATIONS = "notifications"
 
 class FirestoreManager {
     static let shared: FirestoreManager = FirestoreManager()
@@ -1059,5 +1069,34 @@ class FirestoreManager {
         db.collection(COLLECTION_ANALYTICS).document(id).delete { error in
             completion(error == nil ? nil : Constants.Error.unexpectedError)
         }
+    }
+
+    //MARK: - Businesses
+    func fetchBusinessDocument(businessId: String,
+                               subcollection: String,
+                               documentId: String,
+                               completion: @escaping ([String: Any]?)->Void) {
+        db.collection(COLLECTION_BUSINESSES)
+            .document(businessId)
+            .collection(subcollection)
+            .document(documentId)
+            .getDocument { snapshot, error in
+                guard error == nil else { return completion(nil) }
+                completion(snapshot?.data())
+            }
+    }
+
+    func setBusinessDocument(businessId: String,
+                              subcollection: String,
+                              documentId: String,
+                              data: [String: Any],
+                              completion: @escaping (String?)->Void) {
+        db.collection(COLLECTION_BUSINESSES)
+            .document(businessId)
+            .collection(subcollection)
+            .document(documentId)
+            .setData(data, merge: true) { error in
+                completion(error == nil ? nil : Constants.Error.unexpectedError)
+            }
     }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,5 +25,41 @@ service cloud.firestore {
                             request.auth.uid == userId &&
                             validPreferences(request.resource.data.preferences);
     }
+
+    match /businesses/{businessId} {
+      allow read, write: if request.auth != null && request.auth.uid == businessId;
+
+      match /settings/eposConfig/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /inventory/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /sales/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /rules/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /activeDeal/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /analytics/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /ruleAdjustments/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
+      match /notifications/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- define `/businesses` collection security rules with subcollections
- add constants for business collections in `FirestoreManager`
- provide helper functions to read/write business documents

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bd7f6b1ac832795eb5c1402bbbc14