### PR TITLE
Handle user preferences via customer collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,6 +19,20 @@ service cloud.firestore {
       }
     }
 
+    match /customer/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+
+      match /preferences/{docId} {
+        allow read, write: if request.auth != null &&
+                            request.auth.uid == userId &&
+                            validPreferences(request.resource.data);
+      }
+
+      match /availableDeals/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+    }
+
     match /Business/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow create, update: if request.auth != null &&


### PR DESCRIPTION
## Summary
- use collection group queries for `/customer/{userId}/preferences`
- write available deals under `/customer/{userId}/availableDeals`
- add Firestore rules for the new customer preferences path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be5e004d083278f249ec27dceff13