### PR TITLE
Add stub EPOS adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,25 @@ following to test the rule system:
 
 The function responds with a list of results showing whether each rule was
 triggered based on the provided business data.
+
+## EPOS Provider Configuration
+
+SmartDeal integrates with multiple EPOS systems through adapter modules. Each
+business stores credentials in the Firestore document:
+
+```
+businesses/{businessId}/settings/eposConfig
+```
+
+The configuration object must contain at least a `provider` field specifying one
+of the supported providers (`square`, `lightspeed`, `clover`, `toast`,
+`shopify`, `vend`, `eposnow`). The remaining fields depend on the provider but
+typically include:
+
+- `apiKey` or `accessToken` – authentication token issued by the EPOS provider
+- `storeId` or `locationId` – identifier for the store or location
+- `merchantId` – merchant account identifier if required
+
+Adapters read these values via `adapter.config` inside Cloud Functions. Update
+the `eposConfig` document with the required keys for your provider before using
+any EPOS features.

--- a/functions/eposAdapters/baseAdapter.js
+++ b/functions/eposAdapters/baseAdapter.js
@@ -1,17 +1,22 @@
 class BaseAdapter {
-  async fetchSales() {
+  async fetchSales(options = {}) {
+    void options;
     throw new Error('fetchSales not implemented');
   }
 
-  async fetchInventory() {
+  async fetchInventory(options = {}) {
+    void options;
     throw new Error('fetchInventory not implemented');
   }
 
-  async pushDeal() {
+  async pushDeal(deal, options = {}) {
+    void deal;
+    void options;
     throw new Error('pushDeal not implemented');
   }
 
-  async testConnection() {
+  async testConnection(options = {}) {
+    void options;
     throw new Error('testConnection not implemented');
   }
 }

--- a/functions/eposAdapters/clover.js
+++ b/functions/eposAdapters/clover.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class CloverAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = CloverAdapter;

--- a/functions/eposAdapters/eposnow.js
+++ b/functions/eposAdapters/eposnow.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class EposNowAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = EposNowAdapter;

--- a/functions/eposAdapters/index.js
+++ b/functions/eposAdapters/index.js
@@ -1,7 +1,19 @@
 const SquareAdapter = require('./square');
+const LightspeedAdapter = require('./lightspeed');
+const CloverAdapter = require('./clover');
+const ToastAdapter = require('./toast');
+const ShopifyAdapter = require('./shopify');
+const VendAdapter = require('./vend');
+const EposNowAdapter = require('./eposnow');
 
 const adapters = {
   square: SquareAdapter,
+  lightspeed: LightspeedAdapter,
+  clover: CloverAdapter,
+  toast: ToastAdapter,
+  shopify: ShopifyAdapter,
+  vend: VendAdapter,
+  eposnow: EposNowAdapter,
 };
 
 function createAdapter(provider) {

--- a/functions/eposAdapters/lightspeed.js
+++ b/functions/eposAdapters/lightspeed.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class LightspeedAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = LightspeedAdapter;

--- a/functions/eposAdapters/shopify.js
+++ b/functions/eposAdapters/shopify.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class ShopifyAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = ShopifyAdapter;

--- a/functions/eposAdapters/toast.js
+++ b/functions/eposAdapters/toast.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class ToastAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = ToastAdapter;

--- a/functions/eposAdapters/vend.js
+++ b/functions/eposAdapters/vend.js
@@ -1,25 +1,21 @@
 const BaseAdapter = require('./baseAdapter');
 
-class SquareAdapter extends BaseAdapter {
+class VendAdapter extends BaseAdapter {
   async fetchSales(options = {}) {
-    // return stubbed sales data
     return [];
   }
 
   async fetchInventory(options = {}) {
-    // return stubbed inventory data
     return [];
   }
 
   async pushDeal(deal) {
-    // pretend to push a deal
     return { success: true, deal };
   }
 
   async testConnection() {
-    // always succeed for stub
     return true;
   }
 }
 
-module.exports = SquareAdapter;
+module.exports = VendAdapter;

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "description": "Firebase Cloud Functions for SmartDeal",
   "main": "index.js",
   "scripts": {
-    "test": "echo 'No tests specified'"
+    "test": "node tests/run.js"
   },
   "engines": {
     "node": "18"

--- a/functions/tests/run.js
+++ b/functions/tests/run.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const { createAdapter } = require('../eposAdapters');
+
+const providers = [
+  'square',
+  'lightspeed',
+  'clover',
+  'toast',
+  'shopify',
+  'vend',
+  'eposnow',
+];
+
+async function testAdapter(provider) {
+  const adapter = createAdapter(provider);
+  const sales = await adapter.fetchSales({});
+  assert(Array.isArray(sales), `${provider} fetchSales should return array`);
+  const inventory = await adapter.fetchInventory({});
+  assert(Array.isArray(inventory), `${provider} fetchInventory should return array`);
+  const dealRes = await adapter.pushDeal({ id: 1 });
+  assert(dealRes && dealRes.success, `${provider} pushDeal should report success`);
+  const ok = await adapter.testConnection();
+  assert.strictEqual(typeof ok, 'boolean', `${provider} testConnection should return boolean`);
+}
+
+(async () => {
+  for (const p of providers) {
+    await testAdapter(p);
+  }
+  console.log('All adapter tests passed');
+})();


### PR DESCRIPTION
## Summary
- add stub Lightspeed, Clover, Toast, Shopify, Vend and EposNow adapters
- update BaseAdapter to accept options parameters
- export all adapters via `eposAdapters/index.js`
- document EPOS configuration options in README
- add a small node-based test harness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bea9fdc948327be9dd0a0c1277a2e