### PR TITLE
Add rule approvals workflow

### DIFF
--- a/Common/Model/RuleApproval.swift
+++ b/Common/Model/RuleApproval.swift
@@ -1,0 +1,31 @@
+import Foundation
+import FirebaseFirestore
+
+struct RuleApprovalKey {
+    static let triggerType = "triggerType"
+    static let threshold = "threshold"
+    static let approved = "approved"
+}
+
+struct RuleApproval {
+    let documentId: String
+    let triggerType: String
+    let threshold: Double
+    var approved: Bool
+
+    init?(_ document: DocumentSnapshot) {
+        guard let data = document.data() else { return nil }
+        self.documentId = document.documentID
+        self.triggerType = data[RuleApprovalKey.triggerType] as? String ?? ""
+        self.threshold = data[RuleApprovalKey.threshold] as? Double ?? 0
+        self.approved = data[RuleApprovalKey.approved] as? Bool ?? false
+    }
+
+    var data: [String: Any] {
+        [
+            RuleApprovalKey.triggerType: triggerType,
+            RuleApprovalKey.threshold: threshold,
+            RuleApprovalKey.approved: approved
+        ]
+    }
+}

--- a/Controllers/Dashboard/BusinessDashboardView.swift
+++ b/Controllers/Dashboard/BusinessDashboardView.swift
@@ -38,6 +38,24 @@ struct BusinessDashboardView: View {
                         }
                     }
                 }
+
+                if !viewModel.ruleApprovals.isEmpty {
+                    Section(header: Text("Rule Approvals")) {
+                        ForEach(viewModel.ruleApprovals, id: \.documentId) { rule in
+                            HStack {
+                                Text("\(rule.triggerType): \(rule.threshold)")
+                                Spacer()
+                                Button("Approve") {
+                                    viewModel.approve(rule: rule)
+                                }
+                                Button("Reject") {
+                                    viewModel.reject(rule: rule)
+                                }
+                                .foregroundColor(.red)
+                            }
+                        }
+                    }
+                }
             }
             .listStyle(GroupedListStyle())
             .navigationTitle("Dashboard")

--- a/Controllers/Dashboard/BusinessDashboardViewModel.swift
+++ b/Controllers/Dashboard/BusinessDashboardViewModel.swift
@@ -5,14 +5,29 @@ class BusinessDashboardViewModel: ObservableObject {
     @Published var rules: [Rule] = []
     @Published var pendingDeals: [DealItem] = []
     @Published var approvals: [DealItem] = []
+    @Published var ruleApprovals: [RuleApproval] = []
 
     func load() {
         FirestoreManager.shared.fetchRules { [weak self] in self?.rules = $0 ?? [] }
         FirestoreManager.shared.fetchPendingDeals { [weak self] in self?.pendingDeals = $0 ?? [] }
         FirestoreManager.shared.fetchApprovals { [weak self] in self?.approvals = $0 ?? [] }
+        FirestoreManager.shared.fetchRuleApprovals { [weak self] in self?.ruleApprovals = $0 ?? [] }
     }
 
     func redeem(dealId: String) {
         FirestoreManager.shared.redeemApprovedDeal(id: dealId) { _ in }
+    }
+
+    func approve(rule: RuleApproval) {
+        FirestoreManager.shared.approveRule(rule) { [weak self] _ in
+            self?.ruleApprovals.removeAll { $0.documentId == rule.documentId }
+            FirestoreManager.shared.fetchRules { [weak self] in self?.rules = $0 ?? [] }
+        }
+    }
+
+    func reject(rule: RuleApproval) {
+        FirestoreManager.shared.rejectRule(rule) { [weak self] _ in
+            self?.ruleApprovals.removeAll { $0.documentId == rule.documentId }
+        }
     }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -71,6 +71,10 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == businessId;
       }
 
+      match /ruleApprovals/{docId} {
+        allow read, write: if request.auth != null && request.auth.uid == businessId;
+      }
+
       match /notifications/{docId} {
         allow read, write: if request.auth != null && request.auth.uid == businessId;
       }

--- a/functions/index.js
+++ b/functions/index.js
@@ -170,9 +170,12 @@ exports.initializeBusinessRules = functions.firestore
 
     const db = admin.firestore();
     const batch = db.batch();
-    const ref = db.collection('businesses').doc(businessId).collection('rules');
+    const ref = db
+      .collection('businesses')
+      .doc(businessId)
+      .collection('ruleApprovals');
     for (const rule of rules) {
-      batch.set(ref.doc(), rule);
+      batch.set(ref.doc(), { ...rule, approved: false });
     }
     try {
       await batch.commit();


### PR DESCRIPTION
## Summary
- create `ruleApprovals` Firestore collection
- add `RuleApproval` model and FirestoreManager helpers for approval workflow
- surface pending rule approvals on the business dashboard
- initialize default rules in the new approval collection
- update Firestore security rules

## Testing
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_688bf5530d6c8327a7a5014f16937f7b