### PR TITLE
Add scheduled smart deal generation

### DIFF
--- a/functions/smartDealTriggers.js
+++ b/functions/smartDealTriggers.js
@@ -1,0 +1,7 @@
+async function runSmartDealTriggers(metrics = {}, context = {}) {
+  void metrics;
+  void context;
+  return [];
+}
+
+module.exports = { runSmartDealTriggers };


### PR DESCRIPTION
## Summary
- run trigger modules with new `generateSmartDeals` scheduled Cloud Function
- provide placeholder `smartDealTriggers` module

## Testing
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_688cc21435988327a459a51fdf0bb556