### PR TITLE
Add trigger logging and error handling

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -403,10 +403,21 @@ exports.scheduledRuleCheck = functions.pubsub
             .doc(businessId)
             .collection('activeDeal')
             .add(dealData);
+          console.log(
+            `Trigger ${result.triggerType} fired for ${businessId}, generated 1 deal`
+          );
         } catch (err) {
           console.error(`Failed to create activeDeal for ${businessId}:`, err);
         }
-        await logDealActivation(businessId, { ruleId: result.ruleId, salesTotal, inventoryTotal });
+        try {
+          await logDealActivation(businessId, {
+            ruleId: result.ruleId,
+            salesTotal,
+            inventoryTotal,
+          });
+        } catch (err) {
+          console.error(`Failed to log deal activation for ${businessId}:`, err);
+        }
       }
       } catch (err) {
         console.error(`Error processing business ${businessId}:`, err);
@@ -537,6 +548,9 @@ exports.generateSmartDeals = functions.pubsub
           .collection('smartDeals')
           .doc(businessId)
           .set({ deals, quietInfo, updatedAt: timestamp, status: 'pending' });
+        console.log(
+          `generateSmartDeals processed ${businessId}, generated ${deals.length} deals`
+        );
       } catch (err) {
         console.error(`Failed generating smart deals for ${businessId}:`, err);
       }

--- a/functions/smartDealTriggers.js
+++ b/functions/smartDealTriggers.js
@@ -1,7 +1,40 @@
+const { checkLoyaltyGap } = require('./triggerHandlers');
+
+/**
+ * Run smart deal triggers and return generated deals.
+ * Each trigger execution is logged with the business id and
+ * number of deals created. Errors are captured via console.error.
+ */
 async function runSmartDealTriggers(metrics = {}, context = {}) {
-  void metrics;
-  void context;
-  return [];
+  const businessId = context.businessId || 'unknown';
+
+  const triggers = [
+    {
+      name: 'loyalty_gap',
+      async run() {
+        return checkLoyaltyGap(businessId);
+      },
+    },
+  ];
+
+  const allDeals = [];
+
+  for (const trigger of triggers) {
+    try {
+      const deals = await trigger.run(metrics, context);
+      const count = Array.isArray(deals) ? deals.length : 0;
+      console.log(
+        `Trigger ${trigger.name} fired for ${businessId}, generated ${count} deals`
+      );
+      if (count > 0) {
+        allDeals.push(...deals);
+      }
+    } catch (err) {
+      console.error(`Trigger ${trigger.name} failed for ${businessId}:`, err);
+    }
+  }
+
+  return allDeals;
 }
 
 module.exports = { runSmartDealTriggers };


### PR DESCRIPTION
## Summary
- log trigger outputs from scheduled rules and smart deal generation
- report failures per business when running smart deal triggers
- aggregate deal generation inside `runSmartDealTriggers`

## Testing
- `npm --prefix functions test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_688ccab46f7c8327b028d32daaea8d86