### PR TITLE
Add birthday deal generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ following to test the rule system:
 
 The function responds with a list of results showing whether each rule was
 triggered based on the provided business data.
+### Birthday Rule Example
+
+To trigger a promotion on a customer's birthday you can create a rule like:
+
+```json
+{
+  "documentId": "birthday1",
+  "triggerType": "birthday"
+}
+```
+
+When evaluating the rule supply the customer's date of birth in `businessData.birthday`:
+
+```json
+{
+  "birthday": "1990-05-12"
+}
+```
+
 
 ## EPOS Provider Configuration
 

--- a/functions/tests/birthdayDeals.test.js
+++ b/functions/tests/birthdayDeals.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('assert');
+const Module = require('module');
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'firebase-functions') {
+    return {
+      pubsub: { schedule: () => ({ onRun: () => {} }) },
+      https: { onRequest: () => {}, onCall: () => {} },
+      firestore: { document: () => ({ onCreate: () => {}, onWrite: () => {}, onUpdate: () => {} }) },
+      storage: { object: () => ({ onFinalize: () => {} }) },
+    };
+  }
+  if (request === 'firebase-admin') {
+    return { initializeApp() {}, firestore: { FieldValue: { serverTimestamp: () => 'ts' } } };
+  }
+  if (request === '@google-cloud/storage') {
+    return { Storage: class {} };
+  }
+  if (request === 'uuid') {
+    return { v4: () => 'uuid' };
+  }
+  if (request === 'p-limit') {
+    return () => (fn) => fn();
+  }
+  if (['axios', 'xml2js', 'csv-parser'].includes(request)) {
+    return {};
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const { generateBirthdayDealsInternal } = require('../index');
+
+test('generate birthday deals for matching customers', async () => {
+  const fixed = new Date('2023-05-12T00:00:00Z');
+  const RealDate = Date;
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) return new RealDate(fixed);
+      return new RealDate(...args);
+    }
+    static now() { return fixed.getTime(); }
+    static parse(str) { return RealDate.parse(str); }
+    static UTC(...args) { return RealDate.UTC(...args); }
+  };
+
+  const customers = [
+    { id: 'a', birthDate: new Date('1980-05-12') },
+    { id: 'b', birthDate: new Date('1990-08-01') },
+  ];
+  const created = [];
+  const db = {
+    collection(name) {
+      if (name !== 'Customers') throw new Error('unexpected collection');
+      return {
+        get: async () => ({
+          forEach: (cb) => customers.forEach(c => cb({ id: c.id, data: () => c })),
+        }),
+        doc(id) {
+          return {
+            collection(sub) {
+              return {
+                doc() {
+                  return { path: `Customers/${id}/${sub}/auto` };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    batch() {
+      const ops = [];
+      return {
+        set(ref, data) { ops.push({ ref, data }); },
+        commit: async () => { created.push(...ops); },
+      };
+    },
+  };
+
+  await generateBirthdayDealsInternal(db);
+  assert.strictEqual(created.length, 1);
+  assert.strictEqual(created[0].ref.path, 'Customers/a/availableDeals/auto');
+  assert.strictEqual(created[0].data.type, 'birthday');
+
+  global.Date = RealDate;
+});


### PR DESCRIPTION
## Summary
- schedule `generateBirthdayDeals` to push a deal to users with today's birthday
- show how to configure a birthday trigger in the docs
- test birthday deal creation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ceae311608327aacbf4528daf8e35