### PR TITLE
Remove xml fetch utility and refactor rule init

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,6 @@
     "firebase-functions": "^4.0.0",
     "firebase-admin": "^11.0.0",
     "axios": "^1.0.0",
-    "xml2js": "^0.4.0",
     "csv-parser": "^3.0.0",
     "@google-cloud/storage": "^6.0.0",
     "uuid": "^9.0.0",

--- a/functions/tests/birthdayDeals.test.js
+++ b/functions/tests/birthdayDeals.test.js
@@ -23,7 +23,7 @@ Module._load = function(request, parent, isMain) {
   if (request === 'p-limit') {
     return () => (fn) => fn();
   }
-  if (['axios', 'xml2js', 'csv-parser'].includes(request)) {
+  if (['axios', 'csv-parser'].includes(request)) {
     return {};
   }
   return originalLoad(request, parent, isMain);


### PR DESCRIPTION
## Summary
- drop `fetchExternalData` and `xml2js`
- use `fetchUkHolidays()` and `fetchWeather()` when creating business rules
- find the nearest upcoming holiday for expiration logic
- adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cf1d4e1188327a1c21fe1ba2bb707